### PR TITLE
Feat/start delay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES ur_modern_driver
-  CATKIN_DEPENDS hardware_interface controller_manager actionlib control_msgs geometry_msgs roscpp sensor_msgs trajectory_msgs ur_msgs control_panel_ur
+  CATKIN_DEPENDS hardware_interface controller_manager actionlib control_msgs geometry_msgs roscpp sensor_msgs trajectory_msgs ur_msgs
   DEPENDS ur_hardware_interface
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ find_package(catkin REQUIRED COMPONENTS
   trajectory_msgs
   ur_msgs
   tf
-  control_panel_ur
 )
 
 ## System dependencies are found with CMake's conventions

--- a/package.xml
+++ b/package.xml
@@ -52,7 +52,6 @@
   <build_depend>ur_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>realtime_tools</build_depend>
-  <build_depend>control_panel_ur</build_depend>
   <run_depend>hardware_interface</run_depend>
   <run_depend>controller_manager</run_depend>
   <run_depend>actionlib</run_depend>
@@ -66,7 +65,6 @@
   <run_depend>ur_description</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>realtime_tools</run_depend>
-  <run_depend>control_panel_ur</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -52,9 +52,6 @@
 #include <controller_manager/controller_manager.h>
 #include <realtime_tools/realtime_publisher.h>
 
-/// Ur Dashboard
-#include "control_panel_ur/UrDashboard.h"
-
 /// TF
 #include <tf/tf.h>
 #include <tf/transform_broadcaster.h>

--- a/src/ur_ros_wrapper.cpp
+++ b/src/ur_ros_wrapper.cpp
@@ -916,16 +916,11 @@ int main(int argc, char **argv) {
 	} else
 		reverse_port = 50001;
 
-    // Wait for the dashboard to be online before starting the driver
-    {
-        sr::UrDashboard ur_dashboard;
-        ur_dashboard.setHostname(host);
-        while (ros::ok() && !ur_dashboard.initSocketServer())
-        {
-            double timeout = 5.0;
-            ROS_WARN("Could not connect to dashboard, retrying in %.2f seconds", timeout);
-            ros::Duration(timeout).sleep();
-        }
+    // Start delay for CI, sleep x seconds before connecting to the simulated robot
+    double start_delay = 0;
+    if (ros::param::get("~start_delay", start_delay)) {
+        ROS_INFO("Start delay of %.2f seconds, sleeping ....", start_delay);
+        ros::Duration(start_delay).sleep();
     }
 
 	RosWrapper interface(host, reverse_port);


### PR DESCRIPTION
Required to wait for the simulator to be fully up. This dashboard check is apparently no guarantee for that.